### PR TITLE
gradlew assemble task working, switched out some depreciated classes as well as some javafx code

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -25,6 +25,8 @@ plugins {
 apply plugin: 'java'
 apply plugin: 'eclipse'
 apply plugin: 'org.openjfx.javafxplugin'
+// For a Java library module
+apply plugin: 'java-library'
 
 eclipse {
     jdt {
@@ -71,6 +73,7 @@ def keyAlias = 'cscert'
 def tsaURL = 'http://timestamp.comodoca.com/rfc3161'
 
 repositories {
+    mavenCentral()
     // This repository is directly included even though we use jcenter
     // because it makes it easier to get the smallest set of marytts that
     // meets our needs without missing the freetts dependency
@@ -79,6 +82,25 @@ repositories {
     }
     maven {
         url "https://dl.bintray.com/phrack/maven/"
+    }
+    // for xuggle
+    maven {
+        url "https://www.dcm4che.org/maven2/"
+    }
+
+    // for jtok
+    maven {
+        url "https://raw.githubusercontent.com/DFKI-MLT/Maven-Repository/main"
+    }
+
+    // for fast md5
+    maven {
+        url "https://nrgxnat.jfrog.io/artifactory/libs-release/"
+    }
+
+    // for jampack
+    maven {
+        url "https://nexus.terrestris.de/repository/public/"
     }
 }
 
@@ -94,59 +116,59 @@ dependencies {
 //    jfxant files("$javaHome" + "/../lib/ant-javafx.jar")
 
     // FindBugs annotations to suppress warnings
-    compile group: 'com.google.code.findbugs', name: 'annotations', version: '3.+'
+    api group: 'com.google.code.findbugs', name: 'annotations', version: '3.+'
 
     // Raven, exception reporting client (requires logback)
-    compile group: 'com.getsentry.raven', name: 'raven-logback', version: '7.+'
+    api group: 'com.getsentry.raven', name: 'raven-logback', version: '7.+'
 
     // Logback to enable exception reporting
-    compile group: 'ch.qos.logback', name: 'logback-core', version: '1.+'
-    compile group: 'ch.qos.logback', name: 'logback-classic', version: '1.+'
+    api group: 'ch.qos.logback', name: 'logback-core', version: '1.+'
+    api group: 'ch.qos.logback', name: 'logback-classic', version: '1.+'
 
     // bridj is here because webcam-capture depends on it but fetches 0.6.2, which
     // does not play nicely with stackguard in newer versions of the JVM.
-    compile group: 'com.nativelibs4java', name: 'bridj', version: '0.7.0'
-    compile group: 'com.github.sarxos', name: 'webcam-capture', version: '0.3.+'
-    compile group: 'com.github.sarxos', name: 'webcam-capture-driver-ipcam', version: '0.3.+'
-    compile group: 'com.github.sarxos', name: 'webcam-capture-driver-v4l4j', version: '0.3.+'
+    api group: 'com.nativelibs4java', name: 'bridj', version: '0.7.0'
+    api group: 'com.github.sarxos', name: 'webcam-capture', version: '0.3.+'
+    api group: 'com.github.sarxos', name: 'webcam-capture-driver-ipcam', version: '0.3.+'
+    api group: 'com.github.sarxos', name: 'webcam-capture-driver-v4l4j', version: '0.3.+'
 
-    compile group: 'commons-cli', name: 'commons-cli', version: '1.+'
-    compile group: 'org.apache.httpcomponents', name: 'httpclient', version: '4.+'
-    compile group: 'org.apache.httpcomponents', name: 'httpmime', version: '4.+'
+    api group: 'commons-cli', name: 'commons-cli', version: '1.+'
+    api group: 'org.apache.httpcomponents', name: 'httpclient', version: '4.+'
+    api group: 'org.apache.httpcomponents', name: 'httpmime', version: '4.+'
 
     // tts dependencies
-    compile group: 'de.dfki.mary', name: 'marytts-runtime', version: '5.1.+'
-    compile group: 'de.dfki.mary', name: 'marytts-lang-en', version: '5.1.+'
-    compile group: 'de.dfki.mary', name: 'voice-cmu-slt-hsmm', version: '5.1.+'
+    api group: 'de.dfki.mary', name: 'marytts-runtime', version: '5.2.+'
+    api group: 'de.dfki.mary', name: 'marytts-lang-en', version: '5.2.+'
+    api group: 'de.dfki.mary', name: 'voice-cmu-slt-hsmm', version: '5.2.+'
 
     // xuggle for recording and playing back video
-    compile group: 'xuggle', name: 'xuggle-xuggler', version: '5.4'
+    api group: 'xuggle', name: 'xuggle-xuggler', version: '5.4'
 
     // JSON
-    compile group: 'com.googlecode.json-simple', name: 'json-simple', version: '1.1+'
+    api group: 'com.googlecode.json-simple', name: 'json-simple', version: '1.1+'
 
     // OpenImaj
-    compile('org.openimaj:core:1.+') {
+    api('org.openimaj:core:1.+') {
         // OpenImaj transitive dependency that we don't need and that doesn't seem to exist in
         // repos anymore
         exclude group: 'vigna.dsi.unimi.it'
     }
 
     //OpenCV
-    compile 'org.openpnp:opencv:2.4.+'
+    api 'org.openpnp:opencv:2.4.+'
 
     // OSHI to collect HW and system state data
-    compile group: 'com.github.dblock', name: 'oshi-core', version: '3.+'
+    api group: 'com.github.dblock', name: 'oshi-core', version: '3.+'
 
     // JSoup to get processor benchmark data
-    compile group: 'org.jsoup', name: 'jsoup', version: '1.+'
+    api group: 'org.jsoup', name: 'jsoup', version: '1.+'
     
     // Bluetooth libraries, QR code generator, and JSON serializer for headless mode
-    compile 'net.sf.bluecove:bluecove:2.1.0'
+    api 'net.sf.bluecove:bluecove:2.1.0'
     // Assumption that headless mode will only be supported on Linux
-    compile 'net.sf.bluecove:bluecove-gpl:2.1.0'
-    compile 'com.google.zxing:core:3.3.0'
-    compile 'com.google.code.gson:gson:2.8.0'
+    api 'net.sf.bluecove:bluecove-gpl:2.1.0'
+    api 'com.google.zxing:core:3.3.0'
+    api 'com.google.code.gson:gson:2.8.0'
 
     testImplementation group: 'junit', name: 'junit', version: '4.+'
     testImplementation group: 'org.hamcrest', name: 'hamcrest-core', version: '1.+'

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,0 +1,3 @@
+org.gradle.warning.mode=none
+javafxVersion=17
+mainClass=com.shootoff.Start

--- a/src/main/java/com/shootoff/Main.java
+++ b/src/main/java/com/shootoff/Main.java
@@ -18,6 +18,7 @@
 
 package com.shootoff;
 
+import java.awt.*;
 import java.io.BufferedInputStream;
 import java.io.BufferedReader;
 import java.io.File;
@@ -26,9 +27,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.PrintWriter;
-import java.net.HttpURLConnection;
-import java.net.URL;
-import java.net.UnknownHostException;
+import java.net.*;
 import java.nio.file.Files;
 import java.util.Enumeration;
 import java.util.Optional;
@@ -50,8 +49,6 @@ import com.shootoff.plugins.TextToSpeech;
 import com.shootoff.util.HardwareData;
 import com.shootoff.util.SystemInfo;
 import com.shootoff.util.VersionChecker;
-import com.sun.deploy.uitoolkit.impl.fx.HostServicesFactory;
-import com.sun.javafx.application.HostServicesDelegate;
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import javafx.application.Application;
@@ -73,6 +70,8 @@ import javafx.scene.layout.HBox;
 import javafx.scene.paint.Color;
 import javafx.stage.Modality;
 import javafx.stage.Stage;
+
+import javax.swing.event.HyperlinkEvent;
 
 public class Main extends Application {
 	private static final Logger logger = LoggerFactory.getLogger(Main.class);
@@ -519,9 +518,30 @@ public class Main extends Application {
 
 				final Hyperlink lnk = new Hyperlink(link);
 
-				lnk.setOnAction((event) -> {
-					final HostServicesDelegate hostServices = HostServicesFactory.getInstance(this);
-					hostServices.showDocument(link);
+                lnk.setOnAction((event) -> {
+
+                    final Desktop desktop = Desktop.isDesktopSupported() ? Desktop.getDesktop() : null;
+                    if (desktop != null && desktop.isSupported(Desktop.Action.OPEN)) {
+
+                        final URI uriLink;
+
+                        try {
+                            uriLink = new URI(link);
+                        } catch (URISyntaxException e) {
+                            throw new RuntimeException(e);
+                        }
+
+                        try {
+                            desktop.browse(uriLink);
+                        } catch (IOException e) {
+                            throw new RuntimeException(e);
+                        }
+
+
+                    } else {
+                        throw new UnsupportedOperationException("Open action not supported");
+                    }
+
 					lnk.setVisited(true);
 				});
 

--- a/src/main/java/com/shootoff/Start.java
+++ b/src/main/java/com/shootoff/Start.java
@@ -1,0 +1,33 @@
+/*
+ * ShootOFF - Software for Laser Dry Fire Training
+ * Copyright (C) 2016 phrack
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.shootoff;
+
+import com.shootoff.Main;
+
+public class Start {
+
+    /**
+     * Using this pattern ensures that we don't need the javafx
+     * as a module, see https://github.com/javafxports/openjdk-jfx/issues/236#issuecomment-426583174
+     * @param args
+     */
+    public static void main(String[] args) {
+        Main.main(args);
+    }
+}

--- a/src/main/java/com/shootoff/util/SwingFXUtils.java
+++ b/src/main/java/com/shootoff/util/SwingFXUtils.java
@@ -35,7 +35,10 @@ import javafx.scene.image.PixelReader;
 import javafx.scene.image.PixelWriter;
 import javafx.scene.image.WritableImage;
 import javafx.scene.image.WritablePixelFormat;
-import sun.awt.image.IntegerComponentRaster;
+import java.awt.*;
+import java.awt.image.DataBufferInt;
+import java.awt.image.SinglePixelPackedSampleModel;
+import java.awt.image.WritableRaster;
 
 /**
  * This class provides utility methods for converting data types between
@@ -117,16 +120,18 @@ public class SwingFXUtils {
 		}
 
 		PixelWriter pw = wimg.getPixelWriter();
-		IntegerComponentRaster icr = (IntegerComponentRaster) bimg.getRaster();
+        WritableRaster icr =  bimg.getRaster();
 
-		int data[] = icr.getDataStorage();
-		int offset = icr.getDataOffset(0);
-		int scan = icr.getScanlineStride();
+        DataBufferInt data = (DataBufferInt) icr.getDataBuffer();
+        int[] pixels = data.getData();
+        int offset = data.getOffset();
+        SinglePixelPackedSampleModel sm = (SinglePixelPackedSampleModel) icr.getSampleModel();
+        int scan = sm.getScanlineStride();
 
 		PixelFormat<IntBuffer> pf = (bimg.isAlphaPremultiplied() ? PixelFormat.getIntArgbPreInstance()
 				: PixelFormat.getIntArgbInstance());
 
-		pw.setPixels(0, 0, bw, bh, pf, data, offset, scan);
+		pw.setPixels(0, 0, bw, bh, pf, pixels, offset, scan);
 
 		return wimg;
 	}
@@ -261,13 +266,16 @@ public class SwingFXUtils {
 			bimg = new BufferedImage(iw, ih, prefBimgType);
 		}
 
-		IntegerComponentRaster icr = (IntegerComponentRaster) bimg.getRaster();
-		int offset = icr.getDataOffset(0);
-		int scan = icr.getScanlineStride();
-		int data[] = icr.getDataStorage();
+        WritableRaster icr =  bimg.getRaster();
+
+        DataBufferInt data = (DataBufferInt) icr.getDataBuffer();
+        int[] pixels = data.getData();
+        int offset = data.getOffset();
+        SinglePixelPackedSampleModel sm = (SinglePixelPackedSampleModel) icr.getSampleModel();
+        int scan = sm.getScanlineStride();
 
 		WritablePixelFormat<IntBuffer> pf = getAssociatedPixelFormat(bimg);
-		pr.getPixels(0, 0, iw, ih, pf, data, offset, scan);
+		pr.getPixels(0, 0, iw, ih, pf, pixels, offset, scan);
 
 		return bimg;
 	}


### PR DESCRIPTION
This commit gets the `assemble` gradle task passing. It also changes some functionality that I'm not sure works as I havn't been able to run tests. Going to leave it in and incrementally go through the tasks. At some point I plan on moving things from JavaFX to OpenJFX but that is a larger commit. 

```
$ ./gradlew assemble

[Incubating] Problems report is available at: file:///home/ricky/dev/ShootOFF/build/reports/problems/problems-report.html

BUILD SUCCESSFUL in 1s
3 actionable tasks: 3 up-to-date
Consider enabling configuration cache to speed up this build: https://docs.gradle.org/9.2.0/userguide/configuration_cache_enabling.html
```